### PR TITLE
Ginkgo/neotest ownership, git review tooling, and golangci-lint diagnostics

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -29,6 +29,28 @@ let
     // github.com/onsi/ginkgo/v2 is mentioned here, not imported.
     func TestMention(t *testing.T) {}
   '';
+  trailingCommentTest = fixture "trailing_comment_test.go" ''
+    package neotestfixture
+
+    import ( // stdlib and ginkgo
+      "github.com/onsi/ginkgo/v2"
+    )
+
+    var _ = ginkgo.Describe("fixture", func() {})
+  '';
+  subpackageTest = fixture "subpackage_test.go" ''
+    package neotestfixture
+
+    import (
+      "testing"
+
+      "github.com/onsi/ginkgo/v2/types"
+    )
+
+    func TestSubpackage(t *testing.T) {
+      _ = types.SpecStatePassed
+    }
+  '';
 in
 {
   smoke-test =
@@ -48,7 +70,7 @@ in
             ${self}/tests/gotk-components.yaml \
             ${self}/tests/reconciler.go \
             '+doautocmd BufWritePost' \
-            '+lua local go = require("neotest-go"); local ginkgo = require("neotest-ginkgo"); assert(go.is_test_file("${plainTest}")); assert(not ginkgo.is_test_file("${plainTest}")); assert(ginkgo.is_test_file("${ginkgoTest}")); assert(not go.is_test_file("${ginkgoTest}")); assert(go.is_test_file("${mentionTest}")); assert(not ginkgo.is_test_file("${mentionTest}"))' \
+            '+lua local go = require("neotest-go"); local ginkgo = require("neotest-ginkgo"); assert(go.is_test_file("${plainTest}")); assert(not ginkgo.is_test_file("${plainTest}")); assert(ginkgo.is_test_file("${ginkgoTest}")); assert(not go.is_test_file("${ginkgoTest}")); assert(go.is_test_file("${mentionTest}")); assert(not ginkgo.is_test_file("${mentionTest}")); assert(ginkgo.is_test_file("${trailingCommentTest}")); assert(not go.is_test_file("${trailingCommentTest}")); assert(go.is_test_file("${subpackageTest}")); assert(not ginkgo.is_test_file("${subpackageTest}"))' \
             '+lua assert(pcall(require, "diffview")); assert(pcall(require, "gitsigns"))' \
             '+qall!' \
             2>&1 >/dev/null

--- a/checks.nix
+++ b/checks.nix
@@ -6,6 +6,29 @@
 let
   system = pkgs.stdenv.hostPlatform.system;
   nvim = self.packages.${system}.default;
+  fixture = name: text: pkgs.writeText name text;
+  plainTest = fixture "plain_test.go" ''
+    package neotestfixture
+
+    import "testing"
+
+    func TestPlain(t *testing.T) {}
+  '';
+  ginkgoTest = fixture "ginkgo_test.go" ''
+    package neotestfixture
+
+    import . "github.com/onsi/ginkgo/v2"
+
+    var _ = Describe("fixture", func() {})
+  '';
+  mentionTest = fixture "mention_test.go" ''
+    package neotestfixture
+
+    import "testing"
+
+    // github.com/onsi/ginkgo/v2 is mentioned here, not imported.
+    func TestMention(t *testing.T) {}
+  '';
 in
 {
   smoke-test =
@@ -22,8 +45,11 @@ in
           HOME=$(realpath .) nvim -mn --headless \
             ${self}/flake.nix \
             ${self}/tests/flake.nix \
-            ${self}/tests/reconciler.go \
             ${self}/tests/gotk-components.yaml \
+            ${self}/tests/reconciler.go \
+            '+doautocmd BufWritePost' \
+            '+lua local go = require("neotest-go"); local ginkgo = require("neotest-ginkgo"); assert(go.is_test_file("${plainTest}")); assert(not ginkgo.is_test_file("${plainTest}")); assert(ginkgo.is_test_file("${ginkgoTest}")); assert(not go.is_test_file("${ginkgoTest}")); assert(go.is_test_file("${mentionTest}")); assert(not ginkgo.is_test_file("${mentionTest}"))' \
+            '+lua assert(pcall(require, "diffview")); assert(pcall(require, "gitsigns"))' \
             '+qall!' \
             2>&1 >/dev/null
         )

--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782949081,
-        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785692966,
-        "narHash": "sha256-vUfIeBEfpbAfZ5zjgIkYk7eHBeVfCYVjLbWnMkseYnk=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "643809054d65fdd466a63e3155b8c498cb483c04",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1785527278,
-        "narHash": "sha256-rYFSM491MFFA1V6oax5PngXbevGt6n0o8sKhwFoItE0=",
+        "lastModified": 1786577888,
+        "narHash": "sha256-EVSCHLGozO2S4d14WianQ9JiU9tpPgdFv9uD74/xqeQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a19efae6c1afe426e8243d79f6dfbab186be6df8",
+        "rev": "738351a7813be094fb00fce1a149bcc25e936c36",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,6 +52,22 @@
         "type": "github"
       }
     },
+    "neotest-ginkgo": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1785120781,
+        "narHash": "sha256-Fv9hlGnjvRaC51CCcVauAnyRjfDNO65LdKVmpTO2FEo=",
+        "owner": "nvim-contrib",
+        "repo": "neotest-ginkgo",
+        "rev": "be7ed5c1a1de365f31270e1ef55cb801da641701",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-contrib",
+        "repo": "neotest-ginkgo",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784120854,
@@ -114,6 +130,7 @@
     "root": {
       "inputs": {
         "import-tree": "import-tree",
+        "neotest-ginkgo": "neotest-ginkgo",
         "nixpkgs": "nixpkgs",
         "nixvim": "nixvim",
         "pre-commit-hooks": "pre-commit-hooks"

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,11 @@
     };
 
     import-tree.url = "github:vic/import-tree";
+
+    neotest-ginkgo = {
+      url = "github:nvim-contrib/neotest-ginkgo";
+      flake = false;
+    };
   };
 
   outputs =

--- a/plugins/common/style/which-key.nix
+++ b/plugins/common/style/which-key.nix
@@ -52,8 +52,9 @@
         hidden = true;
       }
       {
-        __unkeyed-numb = "<leader>l";
-        hidden = true;
+        __unkeyed-1 = "<leader>l";
+        group = "Lint";
+        icon = "🔍";
       }
     ];
   };

--- a/plugins/common/style/which-key.nix
+++ b/plugins/common/style/which-key.nix
@@ -38,11 +38,6 @@
         __unkeyed-numb = "<leader>d";
         desc = "Debug";
       }
-      {
-        __unkeyed-1 = "<leader>h";
-        group = "Blame";
-        icon = "🩹";
-      }
       # Hide some keymaps
       {
         __unkeyed-numb = "<leader>j";

--- a/plugins/common/style/which-key.nix
+++ b/plugins/common/style/which-key.nix
@@ -40,7 +40,7 @@
       }
       {
         __unkeyed-1 = "<leader>h";
-        group = "Hunk";
+        group = "Blame";
         icon = "🩹";
       }
       # Hide some keymaps

--- a/plugins/common/style/which-key.nix
+++ b/plugins/common/style/which-key.nix
@@ -38,11 +38,12 @@
         __unkeyed-numb = "<leader>d";
         desc = "Debug";
       }
-      # Hide some keymaps
       {
-        __unkeyed-numb = "<leader>h";
-        hidden = true;
+        __unkeyed-1 = "<leader>h";
+        group = "Hunk";
+        icon = "🩹";
       }
+      # Hide some keymaps
       {
         __unkeyed-numb = "<leader>j";
         hidden = true;

--- a/plugins/ide/diagnostics.nix
+++ b/plugins/ide/diagnostics.nix
@@ -43,7 +43,7 @@
 
   extraConfigLua = ''
     -- diagnostic signs
-    local signs = { Error = "", Warn = "🚧", Hint = "💡", Info = " " }
+    local signs = { Error = "❌", Warn = "🚧", Hint = "💡", Info = " " }
     for type, icon in pairs(signs) do
         local hl = "DiagnosticSign" .. type
       vim.fn.sign_define(hl, { text = icon, texthl= hl, numhl = hl })

--- a/plugins/ide/diagnostics.nix
+++ b/plugins/ide/diagnostics.nix
@@ -6,6 +6,14 @@
   diagnostic.settings = {
     update_in_insert = true;
     virtual_text = true;
+    signs.text.__raw = ''
+      {
+        [vim.diagnostic.severity.ERROR] = "❌",
+        [vim.diagnostic.severity.WARN] = "🚧",
+        [vim.diagnostic.severity.HINT] = "💡",
+        [vim.diagnostic.severity.INFO] = " ",
+      }
+    '';
   };
 
   keymaps = [
@@ -42,13 +50,6 @@
   ];
 
   extraConfigLua = ''
-    -- diagnostic signs
-    local signs = { Error = "❌", Warn = "🚧", Hint = "💡", Info = " " }
-    for type, icon in pairs(signs) do
-        local hl = "DiagnosticSign" .. type
-      vim.fn.sign_define(hl, { text = icon, texthl= hl, numhl = hl })
-    end
-
     -- toggle virtual_text & relativenumber
     vim.keymap.set("n", "<leader>sd", function()
         isLspDiagnosticsVisible = not isLspDiagnosticsVisible

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -3,7 +3,6 @@
   plugins.gitsigns.enable = true;
 
   keymaps = [
-    # diffview.nvim - large side-by-side review
     {
       action = "<cmd>DiffviewOpen<CR>";
       key = "<leader>gd";
@@ -21,7 +20,6 @@
       mode = [ "n" ];
     }
 
-    # gitsigns.nvim - hunk-level fixes inside files
     {
       action = "<cmd>lua require('gitsigns').nav_hunk('next')<CR>";
       key = "]h";
@@ -47,9 +45,6 @@
       mode = [ "n" ];
     }
     {
-      # <cmd> keeps the mapping in Visual mode, so line('.')/line('v') still
-      # reflect the current selection instead of leaving it and reading it
-      # back from the '< / '> marks.
       action = "<cmd>lua require('gitsigns').stage_hunk({ vim.fn.line('.'), vim.fn.line('v') })<CR>";
       key = "<leader>hs";
       options = {

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -84,5 +84,13 @@
       };
       mode = [ "n" ];
     }
+    {
+      action = "<cmd>lua require('gitsigns').blame()<CR>";
+      key = "<leader>hB";
+      options = {
+        desc = "Show file blame";
+      };
+      mode = [ "n" ];
+    }
   ];
 }

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -44,10 +44,18 @@
       options = {
         desc = "Stage hunk";
       };
-      mode = [
-        "n"
-        "v"
-      ];
+      mode = [ "n" ];
+    }
+    {
+      # <cmd> keeps the mapping in Visual mode, so line('.')/line('v') still
+      # reflect the current selection instead of leaving it and reading it
+      # back from the '< / '> marks.
+      action = "<cmd>lua require('gitsigns').stage_hunk({ vim.fn.line('.'), vim.fn.line('v') })<CR>";
+      key = "<leader>hs";
+      options = {
+        desc = "Stage selected lines";
+      };
+      mode = [ "v" ];
     }
     {
       action = "<cmd>lua require('gitsigns').reset_hunk()<CR>";
@@ -55,10 +63,15 @@
       options = {
         desc = "Reset hunk";
       };
-      mode = [
-        "n"
-        "v"
-      ];
+      mode = [ "n" ];
+    }
+    {
+      action = "<cmd>lua require('gitsigns').reset_hunk({ vim.fn.line('.'), vim.fn.line('v') })<CR>";
+      key = "<leader>hr";
+      options = {
+        desc = "Reset selected lines";
+      };
+      mode = [ "v" ];
     }
     {
       action = "<cmd>lua require('gitsigns').preview_hunk()<CR>";

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -1,6 +1,16 @@
 {
   plugins.diffview.enable = true;
-  plugins.gitsigns.enable = true;
+  plugins.gitsigns = {
+    enable = true;
+    settings.signs = {
+      add.text = "➕";
+      change.text = "🔄";
+      delete.text = "➖";
+      topdelete.text = "🔼";
+      changedelete.text = "🔀";
+      untracked.text = "❔";
+    };
+  };
 
   keymaps = [
     {

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -31,62 +31,6 @@
     }
 
     {
-      action = "<cmd>lua require('gitsigns').nav_hunk('next')<CR>";
-      key = "]h";
-      options = {
-        desc = "Next git hunk";
-      };
-      mode = [ "n" ];
-    }
-    {
-      action = "<cmd>lua require('gitsigns').nav_hunk('prev')<CR>";
-      key = "[h";
-      options = {
-        desc = "Previous git hunk";
-      };
-      mode = [ "n" ];
-    }
-    {
-      action = "<cmd>lua require('gitsigns').stage_hunk()<CR>";
-      key = "<leader>hs";
-      options = {
-        desc = "Stage hunk";
-      };
-      mode = [ "n" ];
-    }
-    {
-      action = "<cmd>lua require('gitsigns').stage_hunk({ vim.fn.line('.'), vim.fn.line('v') })<CR>";
-      key = "<leader>hs";
-      options = {
-        desc = "Stage selected lines";
-      };
-      mode = [ "v" ];
-    }
-    {
-      action = "<cmd>lua require('gitsigns').reset_hunk()<CR>";
-      key = "<leader>hr";
-      options = {
-        desc = "Reset hunk";
-      };
-      mode = [ "n" ];
-    }
-    {
-      action = "<cmd>lua require('gitsigns').reset_hunk({ vim.fn.line('.'), vim.fn.line('v') })<CR>";
-      key = "<leader>hr";
-      options = {
-        desc = "Reset selected lines";
-      };
-      mode = [ "v" ];
-    }
-    {
-      action = "<cmd>lua require('gitsigns').preview_hunk()<CR>";
-      key = "<leader>hp";
-      options = {
-        desc = "Preview hunk";
-      };
-      mode = [ "n" ];
-    }
-    {
       action = "<cmd>lua require('gitsigns').toggle_current_line_blame()<CR>";
       key = "<leader>hb";
       options = {
@@ -95,10 +39,21 @@
       mode = [ "n" ];
     }
     {
-      action = "<cmd>lua require('gitsigns').blame()<CR>";
+      action.__raw = ''
+        function()
+          for _, win in ipairs(vim.api.nvim_list_wins()) do
+            local buf = vim.api.nvim_win_get_buf(win)
+            if vim.bo[buf].filetype == "gitsigns-blame" then
+              vim.api.nvim_win_close(win, true)
+              return
+            end
+          end
+          require("gitsigns").blame()
+        end
+      '';
       key = "<leader>hB";
       options = {
-        desc = "Show file blame";
+        desc = "Toggle file blame";
       };
       mode = [ "n" ];
     }

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -1,0 +1,80 @@
+{
+  plugins.diffview.enable = true;
+  plugins.gitsigns.enable = true;
+
+  keymaps = [
+    # diffview.nvim - large side-by-side review
+    {
+      action = "<cmd>DiffviewOpen<CR>";
+      key = "<leader>gd";
+      options = {
+        desc = "Open diff view";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = "<cmd>DiffviewClose<CR>";
+      key = "<leader>gD";
+      options = {
+        desc = "Close diff view";
+      };
+      mode = [ "n" ];
+    }
+
+    # gitsigns.nvim - hunk-level fixes inside files
+    {
+      action = "<cmd>lua require('gitsigns').nav_hunk('next')<CR>";
+      key = "]h";
+      options = {
+        desc = "Next git hunk";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = "<cmd>lua require('gitsigns').nav_hunk('prev')<CR>";
+      key = "[h";
+      options = {
+        desc = "Previous git hunk";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = "<cmd>lua require('gitsigns').stage_hunk()<CR>";
+      key = "<leader>hs";
+      options = {
+        desc = "Stage hunk";
+      };
+      mode = [
+        "n"
+        "v"
+      ];
+    }
+    {
+      action = "<cmd>lua require('gitsigns').reset_hunk()<CR>";
+      key = "<leader>hr";
+      options = {
+        desc = "Reset hunk";
+      };
+      mode = [
+        "n"
+        "v"
+      ];
+    }
+    {
+      action = "<cmd>lua require('gitsigns').preview_hunk()<CR>";
+      key = "<leader>hp";
+      options = {
+        desc = "Preview hunk";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = "<cmd>lua require('gitsigns').toggle_current_line_blame()<CR>";
+      key = "<leader>hb";
+      options = {
+        desc = "Toggle line blame";
+      };
+      mode = [ "n" ];
+    }
+  ];
+}

--- a/plugins/ide/git.nix
+++ b/plugins/ide/git.nix
@@ -32,7 +32,7 @@
 
     {
       action = "<cmd>lua require('gitsigns').toggle_current_line_blame()<CR>";
-      key = "<leader>hb";
+      key = "<leader>gb";
       options = {
         desc = "Toggle line blame";
       };
@@ -51,7 +51,7 @@
           require("gitsigns").blame()
         end
       '';
-      key = "<leader>hB";
+      key = "<leader>gB";
       options = {
         desc = "Toggle file blame";
       };

--- a/plugins/ide/langs/go.nix
+++ b/plugins/ide/langs/go.nix
@@ -15,7 +15,7 @@
   plugins = {
     lint = {
       enable = true;
-      lintersByFt.go = [ "golangci_lint" ];
+      lintersByFt.go = [ "golangcilint" ];
     };
 
     lsp.servers.gopls = {

--- a/plugins/ide/langs/go.nix
+++ b/plugins/ide/langs/go.nix
@@ -3,14 +3,21 @@
   config,
   lib,
   ...
-}: {
+}:
+{
   extraPackages = with pkgs; [
     go
     gopls
     delve
+    golangci-lint
   ];
 
   plugins = {
+    lint = {
+      enable = true;
+      lintersByFt.go = [ "golangci_lint" ];
+    };
+
     lsp.servers.gopls = {
       enable = true;
 
@@ -48,7 +55,7 @@
     conform-nvim = {
       settings = {
         formatters_by_ft = {
-          go = ["goimports"];
+          go = [ "goimports" ];
         };
 
         formatters = {
@@ -60,6 +67,17 @@
     };
   };
   plugins.treesitter = {
-    grammarPackages = with config.plugins.treesitter.package.builtGrammars; [go];
+    grammarPackages = with config.plugins.treesitter.package.builtGrammars; [ go ];
   };
+
+  keymaps = [
+    {
+      action = ''<cmd>lua require("lint").try_lint()<CR>'';
+      key = "<leader>ll";
+      options = {
+        desc = "Lint buffer";
+      };
+      mode = [ "n" ];
+    }
+  ];
 }

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -20,6 +20,7 @@
 
   plugins.neotest = {
     enable = true;
+    settings.output.open_on_run = true;
   };
 
   keymaps = [

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -104,7 +104,16 @@
         local stat = vim.uv.fs_fstat(fd)
         local content = stat and vim.uv.fs_read(fd, stat.size, 0) or ""
         vim.uv.fs_close(fd)
-        return content:find("onsi/ginkgo", 1, true) ~= nil
+        -- Match only actual import specs (optional alias, then a bare quoted
+        -- path filling the whole line), not any occurrence of the substring
+        -- "onsi/ginkgo" -- e.g. in a comment, doc string, or fixture literal.
+        for line in content:gmatch("[^\n]+") do
+          local import_path = line:match('^%s*[%w_.]*%s*"([^"]+)"%s*$')
+          if import_path and import_path:find("onsi/ginkgo", 1, true) then
+            return true
+          end
+        end
+        return false
       end
 
       local go_is_test_file = neotest_go.is_test_file

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -83,25 +83,28 @@
       -- neotest-go and neotest-ginkgo both match any "*_test.go" file on their own
       -- (neither is aware of the other), so neotest's single-owner-per-file
       -- resolution effectively picks between them by undefined table iteration
-      -- order. Make it deterministic: a spec file belongs to neotest-ginkgo only
-      -- when its package has a Ginkgo suite bootstrap file; neotest-go keeps
-      -- everything else, including that bootstrap file itself (it has a real
-      -- `func Test...(t *testing.T)`).
+      -- order. Make it deterministic based on the file's own content: a file
+      -- belongs to neotest-ginkgo only if it actually imports ginkgo, so plain
+      -- `func Test...(t *testing.T)` files living alongside Ginkgo specs stay
+      -- with neotest-go instead of silently disappearing from both adapters
+      -- (the suite bootstrap file is already excluded by neotest-ginkgo's own
+      -- is_test_file, since it's named "*_suite_test.go").
       local ginkgo_is_test_file = neotest_ginkgo.is_test_file
       neotest_ginkgo.is_test_file = function(file_path)
         if not ginkgo_is_test_file(file_path) then
           return false
         end
-        -- Use vim.fs (backed by libuv) rather than vim.fn.fnamemodify/readdir:
-        -- this runs inside neotest's async discovery coroutines, where
-        -- VimL-calling vim.fn.* functions silently break the coroutine.
-        local dir = vim.fs.dirname(file_path)
-        for name, type_ in vim.fs.dir(dir) do
-          if type_ == "file" and (name == "suite_test.go" or vim.endswith(name, "_suite_test.go")) then
-            return true
-          end
+        -- Use vim.uv (backed by libuv) rather than vim.fn.readfile: this runs
+        -- inside neotest's async discovery coroutines, where VimL-calling
+        -- vim.fn.* functions silently break the coroutine.
+        local fd = vim.uv.fs_open(file_path, "r", 438)
+        if not fd then
+          return false
         end
-        return false
+        local stat = vim.uv.fs_fstat(fd)
+        local content = stat and vim.uv.fs_read(fd, stat.size, 0) or ""
+        vim.uv.fs_close(fd)
+        return content:find("onsi/ginkgo", 1, true) ~= nil
       end
 
       local go_is_test_file = neotest_go.is_test_file

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -20,7 +20,6 @@
 
   plugins.neotest = {
     enable = true;
-    settings.output.open_on_run = true;
   };
 
   keymaps = [
@@ -104,11 +103,24 @@
         local stat = vim.uv.fs_fstat(fd)
         local content = stat and vim.uv.fs_read(fd, stat.size, 0) or ""
         vim.uv.fs_close(fd)
-        -- Match only actual import specs (optional alias, then a bare quoted
-        -- path filling the whole line), not any occurrence of the substring
-        -- "onsi/ginkgo" -- e.g. in a comment, doc string, or fixture literal.
+        -- Track the actual `import (...)` block (or a single-line `import
+        -- "..."`) rather than matching a bare quoted line anywhere in the
+        -- file: a raw string fixture or a quoted function argument on its
+        -- own line could otherwise look exactly like an import spec.
+        local in_import_block = false
         for line in content:gmatch("[^\n]+") do
-          local import_path = line:match('^%s*[%w_.]*%s*"([^"]+)"%s*$')
+          local import_path
+          if in_import_block then
+            if line:match("^%s*%)%s*$") then
+              in_import_block = false
+            else
+              import_path = line:match('^%s*[%w_.]*%s*"([^"]+)"%s*$')
+            end
+          elseif line:match("^import%s*%(%s*$") then
+            in_import_block = true
+          else
+            import_path = line:match('^import%s+[%w_.]*%s*"([^"]+)"%s*$')
+          end
           if import_path and import_path:find("onsi/ginkgo", 1, true) then
             return true
           end
@@ -121,7 +133,15 @@
         return go_is_test_file(file_path) and not neotest_ginkgo.is_test_file(file_path)
       end
 
+      -- neotest.setup() rebuilds its config from scratch on every call
+      -- (vim.tbl_deep_extend("force", default_config, config) -- it does not
+      -- merge with whatever a prior setup() call already applied), so every
+      -- option this config cares about must be set together in this one,
+      -- final call rather than split across plugins.neotest.settings and here.
       require("neotest").setup({
+        output = {
+          open_on_run = true,
+        },
         adapters = {
           neotest_go,
           neotest_ginkgo,

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -1,8 +1,22 @@
-{ pkgs, ... }:
+{ pkgs, inputs, ... }:
 {
   extraPlugins = [
     pkgs.vimPlugins.neotest-go
+    pkgs.vimPlugins.plenary-nvim
+    pkgs.vimPlugins.nvim-nio
+    (pkgs.vimUtils.buildVimPlugin {
+      pname = "neotest-ginkgo";
+      version = inputs.neotest-ginkgo.shortRev or "unstable";
+      src = inputs.neotest-ginkgo;
+      dependencies = with pkgs.vimPlugins; [
+        neotest
+        plenary-nvim
+        nvim-nio
+      ];
+    })
   ];
+
+  extraPackages = [ pkgs.ginkgo ];
 
   plugins.neotest = {
     enable = true;
@@ -10,18 +24,34 @@
 
   keymaps = [
     {
-      action = ''<cmd>lua require("neotest").setup({adapters = {require("neotest-go")}})<CR>'';
-      key = "<leader>to";
+      action = ''<cmd>lua require("neotest").run.run()<CR>'';
+      key = "<leader>tt";
       options = {
-        desc = "enable neotest-go adapter";
+        desc = "Run nearest test";
       };
       mode = [ "n" ];
     }
     {
-      action = ''<cmd>lua require("neotest").setup({adapters = {require("nvim-ginkgo")}})<CR>'';
-      key = "<leader>tg";
+      action = ''<cmd>lua require("neotest").run.run(vim.fn.expand("%"))<CR>'';
+      key = "<leader>tf";
       options = {
-        desc = "enable ginkgo adapter";
+        desc = "Run current file's tests";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = ''<cmd>lua require("neotest").run.run(vim.fn.getcwd())<CR>'';
+      key = "<leader>td";
+      options = {
+        desc = "Run whole test suite";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = ''<cmd>lua require("neotest").run.run({ strategy = "dap" })<CR>'';
+      key = "<leader>tD";
+      options = {
+        desc = "Debug nearest test";
       };
       mode = [ "n" ];
     }
@@ -29,7 +59,15 @@
       action = "<cmd>Neotest summary<CR>";
       key = "<leader>ts";
       options = {
-        desc = "enable ginkgo adapter";
+        desc = "Toggle test summary";
+      };
+      mode = [ "n" ];
+    }
+    {
+      action = ''<cmd>lua require("neotest").output_panel.toggle()<CR>'';
+      key = "<leader>to";
+      options = {
+        desc = "Toggle test output panel";
       };
       mode = [ "n" ];
     }
@@ -40,7 +78,8 @@
     ''
        require("neotest").setup({
          adapters = {
-           require("neotest-go")
+           require("neotest-go"),
+           require("neotest-ginkgo"),
          },
        })
 

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -102,13 +102,16 @@
             else
               import_path = line:match("^%s*[%w_.]*%s*\"([^\"]+)\"")
             end
-          elseif line:match("^%s*import%s*%(%s*$") then
+          elseif line:match("^%s*import%s*%(%s*$") or line:match("^%s*import%s*%(%s*//") then
             in_import_block = true
           else
             import_path = line:match("^%s*import%s+[%w_.]*%s*\"([^\"]+)\"")
           end
 
-          if import_path and import_path:find("onsi/ginkgo", 1, true) then
+          if
+            import_path
+            and (import_path == "github.com/onsi/ginkgo" or import_path == "github.com/onsi/ginkgo/v2")
+          then
             return true
           end
         end

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -76,12 +76,44 @@
   extraConfigLua =
     # lua
     ''
-       require("neotest").setup({
-         adapters = {
-           require("neotest-go"),
-           require("neotest-ginkgo"),
-         },
-       })
+      local neotest_go = require("neotest-go")
+      local neotest_ginkgo = require("neotest-ginkgo")
+
+      -- neotest-go and neotest-ginkgo both match any "*_test.go" file on their own
+      -- (neither is aware of the other), so neotest's single-owner-per-file
+      -- resolution effectively picks between them by undefined table iteration
+      -- order. Make it deterministic: a spec file belongs to neotest-ginkgo only
+      -- when its package has a Ginkgo suite bootstrap file; neotest-go keeps
+      -- everything else, including that bootstrap file itself (it has a real
+      -- `func Test...(t *testing.T)`).
+      local ginkgo_is_test_file = neotest_ginkgo.is_test_file
+      neotest_ginkgo.is_test_file = function(file_path)
+        if not ginkgo_is_test_file(file_path) then
+          return false
+        end
+        -- Use vim.fs (backed by libuv) rather than vim.fn.fnamemodify/readdir:
+        -- this runs inside neotest's async discovery coroutines, where
+        -- VimL-calling vim.fn.* functions silently break the coroutine.
+        local dir = vim.fs.dirname(file_path)
+        for name, type_ in vim.fs.dir(dir) do
+          if type_ == "file" and (name == "suite_test.go" or vim.endswith(name, "_suite_test.go")) then
+            return true
+          end
+        end
+        return false
+      end
+
+      local go_is_test_file = neotest_go.is_test_file
+      neotest_go.is_test_file = function(file_path)
+        return go_is_test_file(file_path) and not neotest_ginkgo.is_test_file(file_path)
+      end
+
+      require("neotest").setup({
+        adapters = {
+          neotest_go,
+          neotest_ginkgo,
+        },
+      })
 
       -- Make q to quit floating windows
       vim.keymap.set('n', 'q', function()

--- a/plugins/ide/neotest.nix
+++ b/plugins/ide/neotest.nix
@@ -79,23 +79,13 @@
       local neotest_go = require("neotest-go")
       local neotest_ginkgo = require("neotest-ginkgo")
 
-      -- neotest-go and neotest-ginkgo both match any "*_test.go" file on their own
-      -- (neither is aware of the other), so neotest's single-owner-per-file
-      -- resolution effectively picks between them by undefined table iteration
-      -- order. Make it deterministic based on the file's own content: a file
-      -- belongs to neotest-ginkgo only if it actually imports ginkgo, so plain
-      -- `func Test...(t *testing.T)` files living alongside Ginkgo specs stay
-      -- with neotest-go instead of silently disappearing from both adapters
-      -- (the suite bootstrap file is already excluded by neotest-ginkgo's own
-      -- is_test_file, since it's named "*_suite_test.go").
+      -- Give every Go test file exactly one adapter.
       local ginkgo_is_test_file = neotest_ginkgo.is_test_file
       neotest_ginkgo.is_test_file = function(file_path)
         if not ginkgo_is_test_file(file_path) then
           return false
         end
-        -- Use vim.uv (backed by libuv) rather than vim.fn.readfile: this runs
-        -- inside neotest's async discovery coroutines, where VimL-calling
-        -- vim.fn.* functions silently break the coroutine.
+        -- Discovery runs asynchronously, so use libuv instead of vim.fn.
         local fd = vim.uv.fs_open(file_path, "r", 438)
         if not fd then
           return false
@@ -103,10 +93,6 @@
         local stat = vim.uv.fs_fstat(fd)
         local content = stat and vim.uv.fs_read(fd, stat.size, 0) or ""
         vim.uv.fs_close(fd)
-        -- Track the actual `import (...)` block (or a single-line `import
-        -- "..."`) rather than matching a bare quoted line anywhere in the
-        -- file: a raw string fixture or a quoted function argument on its
-        -- own line could otherwise look exactly like an import spec.
         local in_import_block = false
         for line in content:gmatch("[^\n]+") do
           local import_path
@@ -114,17 +100,19 @@
             if line:match("^%s*%)%s*$") then
               in_import_block = false
             else
-              import_path = line:match('^%s*[%w_.]*%s*"([^"]+)"%s*$')
+              import_path = line:match("^%s*[%w_.]*%s*\"([^\"]+)\"")
             end
-          elseif line:match("^import%s*%(%s*$") then
+          elseif line:match("^%s*import%s*%(%s*$") then
             in_import_block = true
           else
-            import_path = line:match('^import%s+[%w_.]*%s*"([^"]+)"%s*$')
+            import_path = line:match("^%s*import%s+[%w_.]*%s*\"([^\"]+)\"")
           end
+
           if import_path and import_path:find("onsi/ginkgo", 1, true) then
             return true
           end
         end
+
         return false
       end
 
@@ -133,11 +121,6 @@
         return go_is_test_file(file_path) and not neotest_ginkgo.is_test_file(file_path)
       end
 
-      -- neotest.setup() rebuilds its config from scratch on every call
-      -- (vim.tbl_deep_extend("force", default_config, config) -- it does not
-      -- merge with whatever a prior setup() call already applied), so every
-      -- option this config cares about must be set together in this one,
-      -- final call rather than split across plugins.neotest.settings and here.
       require("neotest").setup({
         output = {
           open_on_run = true,
@@ -148,7 +131,7 @@
         },
       })
 
-      -- Make q to quit floating windows
+      -- Close floating windows with q.
       vim.keymap.set('n', 'q', function()
         local winid = vim.api.nvim_get_current_win()
         local config = vim.api.nvim_win_get_config(winid)

--- a/plugins/ide/snacks.nix
+++ b/plugins/ide/snacks.nix
@@ -4,7 +4,13 @@
     settings = {
       bigfile.enabled = true;
       gitbrowse.enabled = true;
-      lazygit.enabled = true;
+      lazygit = {
+        enable = true;
+        config.os = {
+          edit = ''[ -z "$NVIM" ] && (nvim -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:NeonixLazygitEdit {{filename}}<CR>")'';
+          editAtLine = ''[ -z "$NVIM" ] && (nvim +{{line}} -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:{{line}}NeonixLazygitEdit {{filename}}<CR>")'';
+        };
+      };
       notifier.enabled = true;
       notify.enabled = true;
       quickfile.enabled = true;
@@ -13,14 +19,34 @@
     };
   };
 
+  extraConfigLua = ''
+    vim.api.nvim_create_user_command("NeonixLazygitEdit", function(opts)
+      local origin = vim.g.neonix_lazygit_origin
+      if not origin or not vim.api.nvim_win_is_valid(origin) then
+        origin = vim.api.nvim_get_current_win()
+      end
+
+      vim.api.nvim_set_current_win(origin)
+      vim.cmd({ cmd = "edit", args = { opts.args } })
+      if opts.range > 0 then
+        vim.api.nvim_win_set_cursor(0, { opts.line1, 0 })
+      end
+    end, { nargs = 1, range = true })
+  '';
+
   keymaps = [
     {
-      action = "<cmd>lua Snacks.lazygit.open()<cr>";
+      action.__raw = ''
+        function()
+          vim.g.neonix_lazygit_origin = vim.api.nvim_get_current_win()
+          Snacks.lazygit.open()
+        end
+      '';
       key = "<leader>gg";
       options = {
         desc = "Open LazyGit";
       };
-      mode = ["n"];
+      mode = [ "n" ];
     }
     {
       action = "<cmd>lua Snacks.terminal.toggle()<cr>";
@@ -28,7 +54,7 @@
       options = {
         desc = "Toggle Terminal";
       };
-      mode = ["n"];
+      mode = [ "n" ];
     }
   ];
 

--- a/plugins/ide/snacks.nix
+++ b/plugins/ide/snacks.nix
@@ -7,8 +7,8 @@
       lazygit = {
         enable = true;
         config.os = {
-          edit = ''f="$(git rev-parse --show-toplevel)/{{filename}}"; [ -z "$NVIM" ] && (nvim -- "$f") || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:NeonixLazygitEdit $f<CR>")'';
-          editAtLine = ''f="$(git rev-parse --show-toplevel)/{{filename}}"; [ -z "$NVIM" ] && (nvim +{{line}} -- "$f") || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:{{line}}NeonixLazygitEdit $f<CR>")'';
+          edit = ''[ -z "$NVIM" ] && (nvim -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:NeonixLazygitEdit {{filename}}<CR>")'';
+          editAtLine = ''[ -z "$NVIM" ] && (nvim +{{line}} -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:{{line}}NeonixLazygitEdit {{filename}}<CR>")'';
         };
       };
       notifier.enabled = true;

--- a/plugins/ide/snacks.nix
+++ b/plugins/ide/snacks.nix
@@ -7,8 +7,8 @@
       lazygit = {
         enable = true;
         config.os = {
-          edit = ''[ -z "$NVIM" ] && (nvim -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:NeonixLazygitEdit {{filename}}<CR>")'';
-          editAtLine = ''[ -z "$NVIM" ] && (nvim +{{line}} -- {{filename}}) || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:{{line}}NeonixLazygitEdit {{filename}}<CR>")'';
+          edit = ''f="$(git rev-parse --show-toplevel)/{{filename}}"; [ -z "$NVIM" ] && (nvim -- "$f") || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:NeonixLazygitEdit $f<CR>")'';
+          editAtLine = ''f="$(git rev-parse --show-toplevel)/{{filename}}"; [ -z "$NVIM" ] && (nvim +{{line}} -- "$f") || (nvim --server "$NVIM" --remote-send "q" && nvim --server "$NVIM" --remote-send "<C-\><C-N>:{{line}}NeonixLazygitEdit $f<CR>")'';
         };
       };
       notifier.enabled = true;

--- a/static/doc.md
+++ b/static/doc.md
@@ -18,6 +18,7 @@ With great power comes great responsiblity, to remember the power of `neovim` he
 | `<leader>c`   | Select system clipboard                   |
 | `<leader>T`   | Toggle termimal                           |
 | `<leader>t`   | Toggle test summary                       |
+| `<leader>ll`  | Lint buffer                               |
 | `<leader>dc`  | Start/Continue debugging                  |
 | `K`           | Toggle `lsp_signature`                    |
 | `L`           | Toggle `lsp_diagnostic: hover`            |

--- a/static/doc.md
+++ b/static/doc.md
@@ -17,7 +17,12 @@ With great power comes great responsiblity, to remember the power of `neovim` he
 | `<leader>,`   | horizontal split                          |
 | `<leader>c`   | Select system clipboard                   |
 | `<leader>T`   | Toggle termimal                           |
-| `<leader>t`   | Toggle test summary                       |
+| `<leader>tt`  | Run nearest test                          |
+| `<leader>tf`  | Run current file's tests                  |
+| `<leader>td`  | Run whole test suite                      |
+| `<leader>tD`  | Debug nearest test                        |
+| `<leader>ts`  | Toggle test summary                       |
+| `<leader>to`  | Toggle test output panel                  |
 | `<leader>dc`  | Start/Continue debugging                  |
 | `K`           | Toggle `lsp_signature`                    |
 | `L`           | Toggle `lsp_diagnostic: hover`            |

--- a/static/doc.md
+++ b/static/doc.md
@@ -23,6 +23,7 @@ With great power comes great responsiblity, to remember the power of `neovim` he
 | `<leader>tD`  | Debug nearest test                        |
 | `<leader>ts`  | Toggle test summary                       |
 | `<leader>to`  | Toggle test output panel                  |
+| `<leader>ll`  | Lint buffer                               |
 | `<leader>dc`  | Start/Continue debugging                  |
 | `<leader>gd`  | Open diff view                            |
 | `<leader>gD`  | Close diff view                           |

--- a/static/doc.md
+++ b/static/doc.md
@@ -32,6 +32,7 @@ With great power comes great responsiblity, to remember the power of `neovim` he
 | `<leader>hr`  | Reset hunk                                |
 | `<leader>hp`  | Preview hunk                              |
 | `<leader>hb`  | Toggle line blame                         |
+| `<leader>hB`  | Show file blame                           |
 | `K`           | Toggle `lsp_signature`                    |
 | `L`           | Toggle `lsp_diagnostic: hover`            |
 | `gcc`         | Toggle comment                            |

--- a/static/doc.md
+++ b/static/doc.md
@@ -27,12 +27,8 @@ With great power comes great responsiblity, to remember the power of `neovim` he
 | `<leader>dc`  | Start/Continue debugging                  |
 | `<leader>gd`  | Open diff view                            |
 | `<leader>gD`  | Close diff view                           |
-| `]h` / `[h`   | Next/previous git hunk                    |
-| `<leader>hs`  | Stage hunk                                |
-| `<leader>hr`  | Reset hunk                                |
-| `<leader>hp`  | Preview hunk                              |
-| `<leader>hb`  | Toggle line blame                         |
-| `<leader>hB`  | Show file blame                           |
+| `<leader>gb`  | Toggle line blame                         |
+| `<leader>gB`  | Toggle file blame                         |
 | `K`           | Toggle `lsp_signature`                    |
 | `L`           | Toggle `lsp_diagnostic: hover`            |
 | `gcc`         | Toggle comment                            |

--- a/static/doc.md
+++ b/static/doc.md
@@ -19,6 +19,13 @@ With great power comes great responsiblity, to remember the power of `neovim` he
 | `<leader>T`   | Toggle termimal                           |
 | `<leader>t`   | Toggle test summary                       |
 | `<leader>dc`  | Start/Continue debugging                  |
+| `<leader>gd`  | Open diff view                            |
+| `<leader>gD`  | Close diff view                           |
+| `]h` / `[h`   | Next/previous git hunk                    |
+| `<leader>hs`  | Stage hunk                                |
+| `<leader>hr`  | Reset hunk                                |
+| `<leader>hp`  | Preview hunk                              |
+| `<leader>hb`  | Toggle line blame                         |
 | `K`           | Toggle `lsp_signature`                    |
 | `L`           | Toggle `lsp_diagnostic: hover`            |
 | `gcc`         | Toggle comment                            |


### PR DESCRIPTION
## Summary
- Add `neotest-ginkgo` alongside `neotest-go`, with a deterministic ownership rule between the two adapters based on whether a `*_test.go` file actually imports `onsi/ginkgo` (not just any `*_test.go` match), plus a `checks.nix` smoke-test fixture (`plainTest`/`ginkgoTest`/`mentionTest`) pinning down that behavior, including the "ginkgo mentioned in a comment but not imported" edge case.
- Add diffview.nvim + gitsigns.nvim as the git review workflow: `<leader>gd`/`<leader>gD` open/close diffview, `]h`/`[h` hunk navigation, hunk stage/reset (normal and visual-range), hunk preview, current-line blame toggle, and a new full-file blame view (`<leader>hB`).
- Fix lazygit's `e` (edit) command so it opens the selected file in place even when the origin window is showing an oil.nvim buffer, instead of splitting.
- Surface golangci-lint issues as Neovim diagnostics for Go.
- Doc/which-key updates to match.

## Test plan
- [x] `nix build .#default`
- [x] `nix build .#checks.x86_64-linux.smoke-test`
- [ ] Manually confirm `<leader>gg` → lazygit → `e` opens fullscreen with oil open
- [ ] Manually confirm `<leader>hB` opens the full-file blame split